### PR TITLE
Fix android-python build failure with rpm-based distros

### DIFF
--- a/android-ndk/activate-ndk.sh
+++ b/android-ndk/activate-ndk.sh
@@ -60,8 +60,8 @@ function activate-ndk-clang() {
     export LDFLAGS="-L$APP_ROOT/lib -L$NDK_LIB_DIR -Wl,--hash-style=both"
 
     # Make package directories
-    mkdir -p $PREFIX/android/$ARCH/include
-    mkdir -p $PREFIX/android/$ARCH/lib
+    mkdir -p "$PREFIX"/android/"$ARCH"/include
+    mkdir -p "$PREFIX"/android/"$ARCH"/lib
 
 }
 
@@ -78,7 +78,7 @@ function validate-lib-arch() {
     elif [ "$ARCH" == "x86_64" ]; then
         expected="ELF 64-bit LSB shared object, x86-64"
     fi
-    output=$(file $lib)
+    output=$(file "$lib")
     echo "$output"
     if [[ $output =~ $expected ]]; then
         echo "OK"
@@ -87,6 +87,6 @@ function validate-lib-arch() {
         exit 1
     fi
 
-    patchelf --remove-rpath $lib
-    readelf --dynamic $lib
+    patchelf --remove-rpath "$lib"
+    readelf --dynamic "$lib"
 }

--- a/android-python/build.sh
+++ b/android-python/build.sh
@@ -81,8 +81,17 @@ do
     # Prefix with lib., remove cpython-310 from name, remove module from name, and copy extensions
     # If using oldsharedmods this should just be Modules
     export MOD_DIR="dist/$ARCH/lib/python3.10/lib-dynload"
-    cd $MOD_DIR; rename 's/^/lib./' *.so; rename 's/.cpython-310//' *.so; rename 's/module//' *.so; cd $SRC_DIR
-    find $MOD_DIR -type f -name "*.so" -exec cp {} "$PREFIX/android/$ARCH/lib/" \;
+    cd "$MOD_DIR"
+    for f in *.so; do mv "$f" "lib.${f}"; done
+    for f in *.so; do
+      mv "$f" "${f//.cpython-310/}";
+    done
+    for f in *.so; do
+      test "$f" != "*module*" && continue
+      mv "$f" "${f//module/}";
+    done
+    cd "$SRC_DIR"
+    find "$MOD_DIR" -type f -name "*.so" -exec cp {} "$PREFIX/android/$ARCH/lib/" \;
 
     # Remove unused stuff
     rm -rf dist/$ARCH/lib/python3.10/test

--- a/android-python/build.sh
+++ b/android-python/build.sh
@@ -31,10 +31,6 @@ do
     export LDFLAGS="$LDFLAGS --sysroot=$ANDROID_TOOLCHAIN/sysroot -llog"
     export _PYTHON_HOST_PLATFORM="$TARGET_HOST"
 
-
-    #cp $RECIPE_DIR/Setup.local $SRC_DIR/Modules/
-    #sed -i s!APP_ROOT=/path/to/app/root/!APP_ROOT=$APP_ROOT/!g $SRC_DIR/Modules/Setup.local
-
     ./configure \
         ac_cv_file__dev_ptmx=yes \
         ac_cv_file__dev_ptc=no \
@@ -59,7 +55,6 @@ do
     sed -i 's!#define HAVE_GETLOADAVG 1!/* #undef HAVE_GETLOADAVG */!g' pyconfig.h
     sed -i 's!#define HAVE_MEMFD_CREATE 1!/* #undef HAVE_MEMFD_CREATE */!g' pyconfig.h
 
-
     # Build libpython
     make -j"$CPU_COUNT" libpython3.so
 
@@ -73,7 +68,6 @@ do
     rm dist/"$ARCH"/lib/python3.10/lib-dynload/xxlim*.so
     rm dist/"$ARCH"/lib/python3.10/lib-dynload/_xx*.so
     rm dist/"$ARCH"/lib/python3.10/lib-dynload/*test*.so
-
 
     mkdir -p "$PREFIX"/android/"$ARCH"/lib
     mkdir -p "$PREFIX"/android/"$ARCH"/python

--- a/android-python/build.sh
+++ b/android-python/build.sh
@@ -5,7 +5,7 @@
 # The full license is in the file LICENSE, distributed with this software.
 # Created on Feb 23, 2018
 # ==================================================================================================
-source $BUILD_PREFIX/android/activate-ndk.sh
+source "$BUILD_PREFIX"/android/activate-ndk.sh
 
 set -e
 
@@ -14,16 +14,16 @@ sed -i 's!INSTSONAME="$LDLIBRARY".$SOVERSION!INSTSONAME="$LDLIBRARY"!g' configur
 sed -i 's!$(VERSION)$(ABIFLAGS)!$(VERSION)!g' configure
 
 # Add patch for parsing conda's python version header
-python $RECIPE_DIR/brand_python.py
+python "$RECIPE_DIR"/brand_python.py
 
-sed -i 's!self.inc_dirs = (self.compiler.include_dirs +!self.inc_dirs = (self.compiler.include_dirs + [os.environ["APP_ROOT"] + "/include", os.environ["NDK_INC_DIR"]] + !g' $SRC_DIR/setup.py
+sed -i 's!self.inc_dirs = (self.compiler.include_dirs +!self.inc_dirs = (self.compiler.include_dirs + [os.environ["APP_ROOT"] + "/include", os.environ["NDK_INC_DIR"]] + !g' "$SRC_DIR"/setup.py
 
 export LD_RUN_PATH="$PREFIX/lib"
 
 for ARCH in $ARCHS
 do
     # Setup compiler for arch and target_api
-    activate-ndk-clang $ARCH
+    activate-ndk-clang "$ARCH"
 
     export CFLAGS="$CFLAGS -fPIC"
     export CCSHARED="$CFLAGS -DPy_BUILD_CORE"
@@ -39,12 +39,12 @@ do
         ac_cv_file__dev_ptmx=yes \
         ac_cv_file__dev_ptc=no \
         ac_cv_have_long_long_format=yes \
-        --with-build-python=$PYTHON \
+        --with-build-python="$PYTHON" \
         --with-ensurepip=install \
-        --with-openssl=$APP_ROOT \
+        --with-openssl="$APP_ROOT" \
         --with-lto \
-        --host=$TARGET_HOST \
-        --build=$ARCH \
+        --host="$TARGET_HOST" \
+        --build="$ARCH" \
         --enable-ipv6 \
         --enable-optimizations \
         --enable-shared
@@ -61,22 +61,22 @@ do
 
 
     # Build libpython
-    make -j$CPU_COUNT libpython3.so
+    make -j"$CPU_COUNT" libpython3.so
 
     # New script now works but skips some modules like ssl, sqlite
     # so stay with the old..
     #make -j$CPU_COUNT oldsharedmods LDFLAGS="$LDFLAGS -L. -lpython3.10 -landroid"
-    make -j$CPU_COUNT sharedmods LDFLAGS="$LDFLAGS -L. -lpython3.10 -landroid"
-    make -C $SRC_DIR install prefix=$SRC_DIR/dist/$ARCH
+    make -j"$CPU_COUNT" sharedmods LDFLAGS="$LDFLAGS -L. -lpython3.10 -landroid"
+    make -C "$SRC_DIR" install prefix="$SRC_DIR"/dist/"$ARCH"
 
     # Remove example/test modules
-    rm dist/$ARCH/lib/python3.10/lib-dynload/xxlim*.so
-    rm dist/$ARCH/lib/python3.10/lib-dynload/_xx*.so
-    rm dist/$ARCH/lib/python3.10/lib-dynload/*test*.so
+    rm dist/"$ARCH"/lib/python3.10/lib-dynload/xxlim*.so
+    rm dist/"$ARCH"/lib/python3.10/lib-dynload/_xx*.so
+    rm dist/"$ARCH"/lib/python3.10/lib-dynload/*test*.so
 
 
-    mkdir -p $PREFIX/android/$ARCH/lib
-    mkdir -p $PREFIX/android/$ARCH/python
+    mkdir -p "$PREFIX"/android/"$ARCH"/lib
+    mkdir -p "$PREFIX"/android/"$ARCH"/python
 
     # Prefix with lib., remove cpython-310 from name, remove module from name, and copy extensions
     # If using oldsharedmods this should just be Modules
@@ -94,20 +94,20 @@ do
     find "$MOD_DIR" -type f -name "*.so" -exec cp {} "$PREFIX/android/$ARCH/lib/" \;
 
     # Remove unused stuff
-    rm -rf dist/$ARCH/lib/python3.10/test
-    rm -rf dist/$ARCH/lib/python3.10/*/test/
-    rm -rf dist/$ARCH/lib/python3.10/*/tests/
-    rm -rf dist/$ARCH/lib/python3.10/__pycache__
-    rm -rf dist/$ARCH/lib/python3.10/plat-*
-    rm -rf dist/$ARCH/lib/python3.10/config-*
-    rm -rf dist/$ARCH/lib/python3.10/tkinter
-    rm -rf dist/$ARCH/lib/python3.10/lib-*
+    rm -rf dist/"$ARCH"/lib/python3.10/test
+    rm -rf dist/"$ARCH"/lib/python3.10/*/test/
+    rm -rf dist/"$ARCH"/lib/python3.10/*/tests/
+    rm -rf dist/"$ARCH"/lib/python3.10/__pycache__
+    rm -rf dist/"$ARCH"/lib/python3.10/plat-*
+    rm -rf dist/"$ARCH"/lib/python3.10/config-*
+    rm -rf dist/"$ARCH"/lib/python3.10/tkinter
+    rm -rf dist/"$ARCH"/lib/python3.10/lib-*
 
     # Copy python
-    cp -RL dist/$ARCH/lib/libpython3.10.so $PREFIX/android/$ARCH/lib/
-    cp -RL dist/$ARCH/include $PREFIX/android/$ARCH
-    cp -RL dist/$ARCH/lib/python3.10/* $PREFIX/android/$ARCH/python
-    validate-lib-arch $PREFIX/android/$ARCH/lib/*.so
+    cp -RL dist/"$ARCH"/lib/libpython3.10.so "$PREFIX"/android/"$ARCH"/lib/
+    cp -RL dist/"$ARCH"/include "$PREFIX"/android/"$ARCH"
+    cp -RL dist/"$ARCH"/lib/python3.10/* "$PREFIX"/android/"$ARCH"/python
+    validate-lib-arch "$PREFIX"/android/"$ARCH"/lib/*.so
 
     # exit 1
 done


### PR DESCRIPTION
Closes #16.

- Uses a for-loop and mv to rename files instead of `rename` which doesn't have the same syntax across distributions
- Fix shellcheck errors, use double quotes to prevent globbing and word splitting of variables